### PR TITLE
CakePHP4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "test": "phpunit",
         "cs-check": "phpcs --colors -p ./src ./tests/TestCase",
         "stan": "phpstan.phar analyse src/ tests/TestCase",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan-shim:^0.11 && mv composer.backup composer.json"
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 && mv composer.backup composer.json"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Provides the features for multiple database connections as master/replica and switching.",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=7.0.0",
-        "cakephp/database": "^3.6"
+        "php": ">=7.2",
+        "cakephp/database": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.14|^6.0",
-        "cakephp/cakephp": "^3.6",
-        "cakephp/cakephp-codesniffer": "^3.0|^4.0@beta"
+        "phpunit/phpunit": "^8.5",
+        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp-codesniffer": "~4.0.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Database/Connection/MasterReplicaConnection.php
+++ b/src/Database/Connection/MasterReplicaConnection.php
@@ -6,6 +6,7 @@ namespace Connehito\CakephpMasterReplica\Database\Connection;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver;
+use Cake\Database\DriverInterface;
 
 /**
  * Connection for handling multi connection(driver) to database.
@@ -64,9 +65,9 @@ class MasterReplicaConnection extends Connection
     /**
      * Get current role's driver
      *
-     * @return \Cake\Database\Driver Current role's driver
+     * @return \Cake\Database\DriverInterface Current role's driver
      */
-    public function getDriver(): Driver
+    public function getDriver(): DriverInterface
     {
         return $this->drivers[$this->role];
     }

--- a/tests/TestCase/Database/Connection/MasterReplicaConnectionTest.php
+++ b/tests/TestCase/Database/Connection/MasterReplicaConnectionTest.php
@@ -38,7 +38,7 @@ class MasterReplicaConnectionTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase/MasterReplicaConnectionIntegrationTest.php
+++ b/tests/TestCase/MasterReplicaConnectionIntegrationTest.php
@@ -15,7 +15,7 @@ class MasterReplicaConnectionIntegrationTest extends TestCase
     /**
      * {@inheritDoc}}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $connection = ConnectionManager::get('test');
         assert($connection instanceof MasterReplicaConnection);


### PR DESCRIPTION
I think CakePHP4 support version must be major versionup.
(e.x. 2.0.0)

CakePHP4 requires at least PHPUnit 8.5, 
but 1.0.0 support PHPUnit 5.7 for CakePHP3.

And difference of `Driver`(CakePHP3) and `DriverInterface`(CakePHP4).